### PR TITLE
Support context

### DIFF
--- a/server.go
+++ b/server.go
@@ -326,7 +326,7 @@ func (s *Server) ttyColor(msg string, colorCode string) string {
 // with the returned route.
 func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused *route) {
 	requestPath := req.URL.Path
-	ctx := Context{req, map[string]string{}, s, w}
+	ctx := Context{req.Context(), req, map[string]string{}, s, w}
 
 	//set some default headers
 	ctx.SetHeader("Server", "web.go", true)

--- a/web.go
+++ b/web.go
@@ -3,6 +3,7 @@
 package web
 
 import (
+	"context"
 	"crypto/tls"
 	"golang.org/x/net/websocket"
 	"log"
@@ -19,6 +20,7 @@ import (
 // about the request, including the http.Request object, the GET and POST params,
 // and acts as a Writer for the response.
 type Context struct {
+	context.Context
 	Request *http.Request
 	Params  map[string]string
 	Server  *Server


### PR DESCRIPTION
Since the context package is part of standard library, I think we should support it.

And web.go had a struct called Context and is used to passing values to handler, I think we can reuse it as a `context.Context` interface. The easist way to do it is embed the `context.Context` from `http.Request.Context()` to web.go's Context.